### PR TITLE
Add contact slide with references to lejo.be

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Clicking/tapping a marker makes it "active" (changes style) and triggers the dis
 Map controls include zoom (Leaflet default) and custom buttons for "Overview" (reset to Flanders view) and "Fit All Markers".
 Introductory Slides:
 Upon initial load, or when navigating via dedicated buttons, full-screen informational "slides" can overlay the map.
-Current slides include: "Introductie," "Onze Kernwerkingen," and "De Toekomst."
+Current slides include: "Introductie," "Onze Kernwerkingen," "De Toekomst," and "Contact."
 These slides provide general statistics and context about LEJO.
+The Contact slide lists our hoofdzetel, e-mail, telefoonnummer, website en links naar de privacyverklaring, vacatures en downloads van <https://lejo.be> en toont sociale media links.
 Info Pane (Sidebar):
 A detailed information panel slides in from the right when a map marker is tapped.
 The content of this pane is dynamically generated based on a structured locations.json file.
@@ -41,7 +42,7 @@ Help Overlay:
 A dedicated help button (?) opens a modal overlay with tips for using the kiosk application (e.g., how to interact with markers, images, navigation).
 Can be closed via a close button (×), clicking the overlay background, or the Escape key.
 Navigation & Controls:
-A persistent bottom bar contains buttons for: Intro, Overview (map), Alle Locaties (map), Werkingen (slide), Toekomst (slide).
+A persistent bottom bar contains buttons for: Intro, Overview (map), Alle Locaties (map), Werkingen (slide), Toekomst (slide), Contact (slide).
 A top-left anniversary logo.
 A top-right "Zoom Level" indicator that updates its text based on the current view (e.g., "Introductie," "Overzicht Vlaanderen," "Locatie: [Name]").
 Data Source (data/locations.json):

--- a/index.html
+++ b/index.html
@@ -53,11 +53,31 @@
              </div>
              <button class="control-btn slide-action-button" onclick="app.showSlide('slide-intro')">Terug naar Begin</button>
         </div>
-         <div class="content-slide" id="slide-toekomst">
+        <div class="content-slide" id="slide-toekomst">
             <h1>De Volgende 45 Jaar</h1>
             <h2>Samen Verder Bouwen</h2>
             <p>Met uw steun blijven we investeren in de kracht van jongeren. Omdat elke jongere kansen verdient. Omdat LEJO verbindt en versterkt.</p>
-             <button class="control-btn slide-action-button" onclick="app.showSlide('slide-intro')">Terug naar Begin</button>
+            <button class="control-btn slide-action-button" onclick="app.showSlide('slide-intro')">Terug naar Begin</button>
+        </div>
+        <div class="content-slide" id="slide-contact">
+            <h1>Contact &amp; Info</h1>
+            <h2 style="font-size:1.4rem;margin-top:-0.5rem;">Lejo vzw &ndash; Versterkt jongeren</h2>
+            <p>Heb je vragen of wil je meer weten over onze werking? Neem gerust contact op.</p>
+            <ul style="list-style:none;padding:0;font-size:1.2rem;line-height:1.6;">
+                <li>📍 Antwerpsesteenweg 701, 9040 Sint-Amandsberg</li>
+                <li>✉️ <a href="mailto:info@lejo.be">info@lejo.be</a></li>
+                <li>☎️ <a href="tel:092232154">09/223 21 54</a></li>
+                <li>🌐 <a href="https://lejo.be" target="_blank" rel="noopener">lejo.be</a></li>
+                <li>📄 <a href="https://lejo.be/privacyverklaring/" target="_blank" rel="noopener">Privacyverklaring</a></li>
+                <li>👉 <a href="https://lejo.be/doe-mee/vacatures/" target="_blank" rel="noopener">Vacatures</a> &middot; <a href="https://lejo.be/downloads/" target="_blank" rel="noopener">Downloads</a></li>
+            </ul>
+            <div style="margin-top:1rem;">
+                <span style="font-weight:bold;margin-right:0.6rem;">Volg ons:</span>
+                <a href="https://www.facebook.com/lejoversterktjongeren" target="_blank" rel="noopener" style="margin-right:0.6rem;">Facebook</a>
+                <a href="https://www.instagram.com/lejoversterktjongeren/" target="_blank" rel="noopener" style="margin-right:0.6rem;">Instagram</a>
+                <a href="https://www.youtube.com/channel/UCdOJC6OhFmTZa-Dpmxekv1g" target="_blank" rel="noopener">YouTube</a>
+            </div>
+            <button class="control-btn slide-action-button" onclick="app.showSlide('slide-intro')">Terug naar Begin</button>
         </div>
     </div>
 
@@ -94,6 +114,7 @@
         <button class="control-btn" onclick="app.fitAllMarkers()" id="btn-fit-markers" title="Toon alle locaties">Alle Locaties</button>
         <button class="control-btn" onclick="app.showSlide('slide-werkingen')" id="btn-werkingen" title="Onze Werkingen">Werkingen</button>
         <button class="control-btn" onclick="app.showSlide('slide-toekomst')" id="btn-toekomst" title="Toekomstvisie">Toekomst</button>
+        <button class="control-btn" onclick="app.showSlide('slide-contact')" id="btn-contact" title="Contactinformatie">Contact</button>
     </div>
 
     <div id="lightbox" class="lightbox-overlay">
@@ -117,7 +138,7 @@
                 <li>👆 **Tik op markers** op de kaart om details van een LEJO locatie te zien.</li>
                 <li>🖼️ **Tik op afbeeldingen** (hoofdafbeelding of galerij) in het infopaneel om ze vergroot te bekijken.</li>
                 <li>▶️ **Tik op video/media knoppen** om video's af te spelen of links te openen (YouTube/PDF in app, andere extern).</li>
-                <li>🗺️ Gebruik de knoppen onderaan voor **kaartnavigatie** (Intro, Overzicht, Alle Locaties) en om **informatiepagina's** (Werkingen, Toekomst) te bekijken.</li>
+                <li>🗺️ Gebruik de knoppen onderaan voor **kaartnavigatie** (Intro, Overzicht, Alle Locaties) en om **informatiepagina's** (Werkingen, Toekomst, Contact) te bekijken.</li>
                 <li>ESC Gebruik de **Escape-toets** (indien fysiek toetsenbord beschikbaar) of de **sluitknoppen (×)** om vensters te sluiten.</li>
                 <li>🔍 Zoom in en uit op de kaart met de **+/- knoppen** rechtsonder of door te **knijpen/spreiden** met twee vingers op het scherm.</li>
             </ul>

--- a/js/app.js
+++ b/js/app.js
@@ -480,6 +480,7 @@ class App {
             if (slideId === 'slide-intro') zoomText = 'Introductie';
             else if (slideId === 'slide-werkingen') zoomText = 'Onze Werkingen';
             else if (slideId === 'slide-toekomst') zoomText = 'De Toekomst';
+            else if (slideId === 'slide-contact') zoomText = 'Contact';
             this.updateZoomLevelIndicator(zoomText);
             if (window.location.hash) history.pushState(null, null, window.location.pathname + window.location.search);
             const mapInstance = this.mapManager.getMapInstance();
@@ -541,12 +542,14 @@ class App {
         const introBtn = document.getElementById('btn-intro');
         const werkBtn = document.getElementById('btn-werkingen');
         const toekBtn = document.getElementById('btn-toekomst');
+        const contactBtn = document.getElementById('btn-contact');
         const overviewBtn = document.getElementById('btn-overview');
         const fitMarkersBtn = document.getElementById('btn-fit-markers');
 
         if (introBtn) introBtn.disabled = (this.currentSlideId === 'slide-intro');
         if (werkBtn) werkBtn.disabled = (this.currentSlideId === 'slide-werkingen');
         if (toekBtn) toekBtn.disabled = (this.currentSlideId === 'slide-toekomst');
+        if (contactBtn) contactBtn.disabled = (this.currentSlideId === 'slide-contact');
 
         const mapInstance = this.mapManager.getMapInstance();
         if (overviewBtn && mapInstance) {


### PR DESCRIPTION
## Summary
- add a new **Contact** slide with address, phone, website and social links
- include a Contact button in the controls bar
- update help text and zoom level logic for the new slide
- update README to mention the Contact slide
- expand the Contact slide with tagline, privacy policy and handy links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68400c5f18ac833188d8c82e7c663c60