### PR TITLE
Fix bug with App initialization

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -53,18 +53,6 @@ class App {
         }
     }
 
-    initialize() {
-        if (!this.mapManager || !this.ui) {
-            console.error("App initialization skipped due to missing core components.");
-            return;
-        }
-        this.mapManager.initializeMap();
-        this.loadDataAndSetup();
-        this.setupEventListeners();
-        this.updateZoomLevelIndicator('Introductie');
-        this.updateControlsActiveState();
-    }
-
     async loadDataAndSetup() {
         this.allLocationsData = await this.mapManager.fetchAndLoadMarkers('data/locations.json');
         this.handleLocationHash();


### PR DESCRIPTION
## Summary
- remove duplicate `initialize` method in `app.js`
- ensure kiosk manager logic runs when the app starts

## Testing
- `grep -n "initialize()" js/app.js`

------
https://chatgpt.com/codex/tasks/task_e_68402ef43e048331b464af9d056fa2b6